### PR TITLE
feat: :sparkles: use pointer cursor on theme switcher

### DIFF
--- a/src/Components/HomePage/Header.tsx
+++ b/src/Components/HomePage/Header.tsx
@@ -30,7 +30,7 @@ const Header:React.FC<Props> = (props) => {
     return (
         <nav className="w-full md:pb-1 md:pt-5 py-2">
             <div className="flex flex-row justify-between container items-center text-lg font-semibold text-gray-800 dark:text-gray-200">
-                <div onClick={() => props.toggleTheme()} className="md:ml-0 ml-3">
+                <div onClick={() => props.toggleTheme()} className="md:ml-0 ml-3 cursor-pointer">
                     {props.currentTheme === 'dark' ? <i className="fas fa-moon"/> : <i className="fas fa-sun"/>}
                 </div>
                 <div className="md:flex hidden flex-row">


### PR DESCRIPTION
Changes the cursor on the theme switcher to be a pointer, as it is a clickable button.

![image](https://user-images.githubusercontent.com/44986932/196672198-6ceaefc1-9d30-4a43-9eef-3e4f7fc1eade.png)
